### PR TITLE
Support wide characters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,9 +10,9 @@ AC_PROG_CC
 
 AC_CHECK_LIB([curl], [curl_easy_init])
 AC_CHECK_LIB([jsoncpp], [_ZNK4Json5Value4sizeEv])
-AC_CHECK_LIB([menu], [free_item])
-AC_CHECK_LIB([ncurses], [initscr])
-AC_CHECK_LIB([panel], [new_panel])
+AC_CHECK_LIB([menuw], [free_item])
+AC_CHECK_LIB([ncursesw], [initscr])
+AC_CHECK_LIB([panelw], [new_panel])
 
 AC_CHECK_HEADERS([stdlib.h string.h termios.h unistd.h])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = feednix 
 feednix_SOURCES = main.cpp FeedlyProvider.cpp CursesProvider.cpp 
-AM_CFLAGS = -lcurl -ljsoncpp -lmenu -lpanel -lncursesw
-AM_LIBS = curl jsoncpp menu panel ncurses 
 feednix_CPPFLAGS =-DDEBUG -std=c++11 -Wall 
+AM_CFLAGS = -lcurl -ljsoncpp -lmenuw -lpanelw -lncursesw
+AM_LIBS = curl jsoncpp menuw panelw ncursesw


### PR DESCRIPTION
Feednix cannot add items for entries with wide (a.k.a. multi-byte) characters.  It fails on creating items using `new_item`, which returns `nullptr` due to `E_BAD_ARGUMENT`.  This pull requests replaces libraries with ones supporting wide characters.

I confirmed that entries with wide characters were shown after this change on Ubuntu 20.04.1 LTS.