### PR TITLE
Fix an initial launch failure due to an unsupported mkdir option

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = feednix 
 feednix_SOURCES = main.cpp FeedlyProvider.cpp CursesProvider.cpp 
-feednix_CPPFLAGS =-DDEBUG -std=c++11 -Wall 
+feednix_CPPFLAGS = -DDEBUG -std=c++17 -Wall
 AM_CFLAGS = -lcurl -ljsoncpp -lmenuw -lpanelw -lncursesw
 AM_LIBS = curl jsoncpp menuw panelw ncursesw

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <iostream>
 #include <string.h>
 #include <signal.h>
@@ -7,6 +8,8 @@
 #include <stdio.h>
 
 #include "CursesProvider.h"
+
+namespace fs = std::filesystem;
 
 #define HOME_PATH getenv("HOME")
 CursesProvider *curses;
@@ -36,10 +39,14 @@ int main(int argc, char **argv){
         bool verboseEnabled = false;
         bool changeTokens = false;
 
-        if(fopen(std::string(std::string(HOME_PATH) + "/.config/feednix/config.json").c_str(), "r") == NULL){
-                system(std::string("mkdir -P" + std::string(HOME_PATH) + "/.config/feednix &> /dev/null").c_str());
-                system(std::string("cp /etc/xdg/feednix/config.json " + std::string(HOME_PATH) + "/.config/feednix/config.json").c_str());
-                system(std::string("chmod 600 " + std::string(HOME_PATH) + "/.config/feednix/config.json").c_str());
+        // Create ~/.config/feednix/config.json if it doesn't exist.
+        const auto home_path = fs::path{HOME_PATH};
+        const auto config_dir = home_path / ".config" / "feednix";
+        const auto config_path = config_dir / "config.json";
+        fs::create_directories(config_dir);
+        if(!fs::exists(fs::status(config_path))){
+                fs::copy_file("/etc/xdg/feednix/config.json", config_path);
+                fs::permissions(config_path, fs::perms::owner_read | fs::perms::owner_write);
         }
 
         char *sys_tmpdir = getenv("TMPDIR");


### PR DESCRIPTION
Feednix cannot complete the initial launch due to an error on Ubuntu 20.04.1 LTS because its `mkdir` doesn't support `-P` option.

```
mkdir: invalid option -- 'P'
Try 'mkdir --help' for more information.
```

This pull request rewrites some file operations with `std::filesystem` (which requires C++17 or above) to make them portable.

I confirmed that Feednix with this change was able to launch even when `~/.config/feednix` was missing.
