### PR TITLE
Replace deprecated methods

### DIFF
--- a/src/FeedlyProvider.cpp
+++ b/src/FeedlyProvider.cpp
@@ -48,7 +48,7 @@ void FeedlyProvider::authenticateUser(){
         if(!parsingSuccesful){
                 if(!isLogStreamOpen) openLogStream();
                 log_stream << "ERROR: Log In Failed - Unable to read from config file" << std::endl;
-                log_stream << reader.getFormatedErrorMessages() << std::endl;
+                log_stream << reader.getFormattedErrorMessages() << std::endl;
                 exit(EXIT_FAILURE);
         }
         if(root["developer_token"] == Json::nullValue || changeTokens){
@@ -101,7 +101,7 @@ const std::map<std::string, std::string>* FeedlyProvider::getLabels(){
                 if(!isLogStreamOpen) openLogStream();
                 log_stream << "ERROR: Failed to Retrive Categories" << std::endl;
                 if(!parsingSuccesful)
-                        log_stream << "\nERROR: Failed to parse tokens file" << reader.getFormatedErrorMessages() << std::endl;
+                        log_stream << "\nERROR: Failed to parse tokens file" << reader.getFormattedErrorMessages() << std::endl;
                 if(curl_res != CURLE_OK)
                         log_stream << "curl_easy_perform() failed : " << curl_easy_strerror(curl_res) << std::endl;
 
@@ -146,7 +146,7 @@ const std::vector<PostData>* FeedlyProvider::giveStreamPosts(const std::string& 
         if(!data || curl_res != CURLE_OK || !parsingSuccesful){
                 if(!isLogStreamOpen) openLogStream();
                 if(!parsingSuccesful)
-                        log_stream << "\nERROR: Failed to parse tokens file" << reader.getFormatedErrorMessages() << std::endl;
+                        log_stream << "\nERROR: Failed to parse tokens file" << reader.getFormattedErrorMessages() << std::endl;
                 if(curl_res != CURLE_OK)
                         log_stream << "curl_easy_perform() failed : " << curl_easy_strerror(curl_res) << std::endl;
 


### PR DESCRIPTION
`make` with g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0 shows following warnings about calling a deprecated function.  This pull request replaces the function with its successor.

```
FeedlyProvider.cpp: In member function ‘void FeedlyProvider::authenticateUser()’:
FeedlyProvider.cpp:51:63: warning: ‘std::string Json::Reader::getFormatedErrorMessages() const’ is deprecated: Use getFormattedErrorMessages() instead. [-Wdeprecated-declarations]
   51 |                 log_stream << reader.getFormatedErrorMessages() << std::endl;
      |                                                               ^
In file included from /usr/include/jsoncpp/json/json.h:11,
                 from FeedlyProvider.cpp:9:
/usr/include/jsoncpp/json/reader.h:114:18: note: declared here
  114 |   JSONCPP_STRING getFormatedErrorMessages() const;
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~
FeedlyProvider.cpp: In member function ‘const std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >* FeedlyProvider::getLabels()’:
FeedlyProvider.cpp:104:113: warning: ‘std::string Json::Reader::getFormatedErrorMessages() const’ is deprecated: Use getFormattedErrorMessages() instead. [-Wdeprecated-declarations]
  104 |                         log_stream << "\nERROR: Failed to parse tokens file" << reader.getFormatedErrorMessages() << std::endl;
      |                                                                                                                 ^
In file included from /usr/include/jsoncpp/json/json.h:11,
                 from FeedlyProvider.cpp:9:
/usr/include/jsoncpp/json/reader.h:114:18: note: declared here
  114 |   JSONCPP_STRING getFormatedErrorMessages() const;                                                                                                                                                                                                                |                  ^~~~~~~~~~~~~~~~~~~~~~~~
FeedlyProvider.cpp: In member function ‘const std::vector<PostData>* FeedlyProvider::giveStreamPosts(const string&, bool)’:
FeedlyProvider.cpp:149:113: warning: ‘std::string Json::Reader::getFormatedErrorMessages() const’ is deprecated: Use getFormattedErrorMessages() instead. [-Wdeprecated-declarations]
  149 |                         log_stream << "\nERROR: Failed to parse tokens file" << reader.getFormatedErrorMessages() << std::endl;
      |                                                                                                                 ^
In file included from /usr/include/jsoncpp/json/json.h:11,
                 from FeedlyProvider.cpp:9:                                                                                                                                                                                                                         /usr/include/jsoncpp/json/reader.h:114:18: note: declared here                                                                                                                                                                                                        114 |   JSONCPP_STRING getFormatedErrorMessages() const;                                                                                                                                                                                                                |                  ^~~~~~~~~~~~~~~~~~~~~~~~
```

I confirmed that `make` stopped showing warnings on Ubuntu 20.04.1 LTS after this change.