### PR TITLE
Add a setting to configure seconds to mark an article as read

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ to keep this project open source, hence this new method.
 * A : Mark category read
 * R : Refersh highlighted category (Retrive post by category)
 
+## Setting
+
+Feednix will create a setting file on the first launch at `~/.config/feednix/config.json`.
+
+* `seconds_to_mark_as_read` (integer, default = `0`) : Indicates how many seconds an article should have been shown for when Feednix marks it as read automatically.  A negative value indicates that Feednix won't mark an article as read unless you does so by "r" key.
+
 ## Contributing
 
 Please visit this [page](https://feednix-jarkore.rhcloud.com) for details.

--- a/config.json
+++ b/config.json
@@ -22,13 +22,17 @@
                 "item_highlight" : 2,
                 "read_item" : 3
         },
-	"ctg_win_width" : 40,
+        "ctg_win_width" : 40,
         //"view_win_height" : 200,
-	"view_win_height_per" : 50,
+        "view_win_height_per" : 50,
         // Count of posts to be retrived per request. Maximum is 10000
         "posts_retrive_count" : "500",
         //Feedly API Allows for two sort types:
                 // Newest(default) false 
                 // Oldest true 
-        "rank" : false 
+        "rank" : false,
+        // Mark an article as read if it has been shown for more than the specified seconds.
+        // A negative value indicates that the article won't be marked as read
+        // unless you open it with the browser or mark it as read explicitly.
+        "seconds_to_mark_as_read": 0
 }

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <iostream>
 #include <curses.h>
 #include <menu.h>
@@ -24,6 +25,8 @@ class CursesProvider{
                 ITEM **ctgItems, **postsItems;
                 MENU *ctgMenu, *postsMenu;
                 std::string lastEntryRead, statusLine[3];
+                std::chrono::time_point<std::chrono::steady_clock> lastPostSelectionTime{std::chrono::time_point<std::chrono::steady_clock>::max()};
+                std::chrono::seconds secondsToMarkAsRead;
                 bool currentRank = 0;
                 int totalPosts = 0, numRead = 0, numUnread = 0;
                 int viewWinHeightPer = VIEW_WIN_HEIGHT_PER, viewWinHeight = 0, ctgWinWidth = CTG_WIN_WIDTH;
@@ -34,6 +37,7 @@ class CursesProvider{
                 void ctgMenuCallback(char* label);
                 void postsMenuCallback(ITEM* item, bool preview);
                 void markItemRead(ITEM* item);
+                void markCurrentItemReadAutomatically();
                 void win_show(WINDOW *win, char *label, int label_color, bool highlight);
                 void print_in_middle(WINDOW *win, int starty, int startx, int width, char *string, chtype color);
                 void print_in_center(WINDOW *win, int starty, int startx, int height, int width, char *string, chtype color);

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -37,7 +37,7 @@ class CursesProvider{
                 void ctgMenuCallback(char* label);
                 void postsMenuCallback(ITEM* item, bool preview);
                 void markItemRead(ITEM* item);
-                void markCurrentItemReadAutomatically();
+                void markItemReadAutomatically(ITEM* item);
                 void win_show(WINDOW *win, char *label, int label_color, bool highlight);
                 void print_in_middle(WINDOW *win, int starty, int startx, int width, char *string, chtype color);
                 void print_in_center(WINDOW *win, int starty, int startx, int height, int width, char *string, chtype color);


### PR DESCRIPTION
Feednix currently marks an article as read on showing it.  However, I personally prefer marking articles as read explicitly.  Feedly has "Auto-Mark As Read On Scroll" setting for that.

This pull request adds "seconds_to_mark_as_read" setting.  Its value is an integer indicating how many seconds the article should have been shown for when Feednix marks the current article as read automatically.  The default value is 0, meaning that an article will be marked as read whenever it's selected (~= the behavior without this change).  A negative value indicates that an article will never be marked as read unless the user explicitly does that by "r" key.

I confirmed that:

- 'seconds_to_mark_as_read: 0' always marks a selected item as read.  That now happens when the selection changes or Feednix terminates, unlike the old behavior where an article is marked as read on being shown.
- 'seconds_to_mark_as_read: -1' never mark a selected item as read.
- 'seconds_to_mark_as_read: 2' marks a selected item as read only when it has been shown for more than (approximately) 2 seconds.