### PR TITLE
Handle Feedly API error

### DIFF
--- a/src/FeedlyProvider.cpp
+++ b/src/FeedlyProvider.cpp
@@ -342,7 +342,8 @@ Json::Value FeedlyProvider::curl_retrieve(const std::string& uri, const Json::Va
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, data_holder);
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
 
-        if(!jsonCont.isNull()){
+        const auto isPost{ !jsonCont.isNull() };
+        if(isPost){
                 Json::StyledWriter writer;
                 std::string document = writer.write(jsonCont);
                 curl_easy_setopt(curl, CURLOPT_POST, true);
@@ -359,6 +360,10 @@ Json::Value FeedlyProvider::curl_retrieve(const std::string& uri, const Json::Va
 
         fclose(data_holder);
         curl_easy_cleanup(curl);
+
+        if(isPost){
+                return Json::Value();
+        }
 
         std::ifstream data(TEMP_PATH.c_str(), std::ifstream::binary);
         if(!data){

--- a/src/FeedlyProvider.h
+++ b/src/FeedlyProvider.h
@@ -1,4 +1,9 @@
 #include <curl/curl.h>
+#ifdef __APPLE__
+#include <json/json.h>
+#else
+#include <jsoncpp/json/json.h>
+#endif
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -32,12 +37,12 @@ class FeedlyProvider{
         public:
                 FeedlyProvider();
                 void authenticateUser();
-                bool markPostsRead(const std::vector<std::string>* ids);
-                bool markPostsSaved(const std::vector<std::string>* ids);
-                bool markPostsUnsaved(const std::vector<std::string>* ids);
-                bool markCategoriesRead(const std::string& id, const std::string& lastReadEntryId);
-                bool markPostsUnread(const std::vector<std::string>* ids);
-                bool addSubscription(bool newCategory, const std::string& feed, std::vector<std::string> categories, const std::string& title = "");
+                void markPostsRead(const std::vector<std::string>* ids);
+                void markPostsSaved(const std::vector<std::string>* ids);
+                void markPostsUnsaved(const std::vector<std::string>* ids);
+                void markCategoriesRead(const std::string& id, const std::string& lastReadEntryId);
+                void markPostsUnread(const std::vector<std::string>* ids);
+                void addSubscription(bool newCategory, const std::string& feed, std::vector<std::string> categories, const std::string& title = "");
                 const std::vector<PostData>* giveStreamPosts(const std::string& category, bool whichRank = 0);
                 const std::map<std::string, std::string>* getLabels();
                 const std::string getUserId();
@@ -57,7 +62,7 @@ class FeedlyProvider{
                 std::vector<PostData> feeds;
                 void getCookies();
                 void enableVerbose();
-                void curl_retrive(const std::string&);
+                Json::Value curl_retrieve(const std::string& uri, const Json::Value& jsonCont = Json::Value::nullSingleton());
                 void extract_galx_value();
                 void echo(bool on);
                 void openLogStream();


### PR DESCRIPTION
During working on another pull request, Feednix started to crash on its launch.  It was because Feedly API reached its limit and started returning an error response which Feednix couldn't recognize.

This pull request merges different places calling Feedly APIs into `retrieve_curl` with a new handling logic for error responses.  In case of any error, it throws an exception.  `CursesProvider` handles it and shows its message as a status message.

I confirmed:
- Marking, unmarking, saving, unsaving entries keeps working same when Feedly API calls are successful.
- Feednix shows an error status message when Feedly API reaches its limit.

![Feednix showing an error status message when Feedly API reaches its limit](https://user-images.githubusercontent.com/25241373/105620752-8610cd80-5e43-11eb-8269-e14ab01265fc.png)