### PR TITLE
Use alternate URL

### DIFF
--- a/src/FeedlyProvider.cpp
+++ b/src/FeedlyProvider.cpp
@@ -170,8 +170,21 @@ const std::vector<PostData>* FeedlyProvider::giveStreamPosts(const std::string& 
                 return NULL;
         }
 
-        for(unsigned int i = 0; i < root["items"].size(); i++){
-                feeds.push_back(PostData{root["items"][i]["summary"]["content"].asString(), root["items"][i]["title"].asString(), root["items"][i]["id"].asString(), root["items"][i]["originId"].asString(), root["items"][i]["origin"]["title"].asString()});
+        for(const auto& item : root["items"]){
+                auto url = std::string{};
+                for(const auto& alternate : item["alternate"]){
+                        if(alternate["type"].asString() == "text/html"){
+                                url = alternate["href"].asString();
+                                break;
+                        }
+                }
+
+                feeds.push_back({
+                    item["summary"]["content"].asString(),
+                    item["title"].asString(),
+                    item["id"].asString(),
+                    url,
+                    item["origin"]["title"].asString()});
         }
 
         data.close();


### PR DESCRIPTION
Feednix cannot open entries of some feeds (e.g. YouTube feeds).  It uses `originId` in [Feedly Entries API](https://developer.feedly.com/v3/entries/), which is not necessarily a URL.

This pull request uses an alternate URL for "text/html".  It should always have the URL of the original web page.

I confirmed that Feednix with this change was able to open an entry of a YouTube feed by "o" key.