### PR TITLE
Fix a segmentation fault on -h

### DIFF
--- a/src/CursesProvider.cpp
+++ b/src/CursesProvider.cpp
@@ -680,7 +680,7 @@ void CursesProvider::update_infoline(const char* info){
         mvprintw(LINES - 1, 0, info);
         attroff(COLOR_PAIR(5));
 }
-void CursesProvider::cleanup(){
+CursesProvider::~CursesProvider(){
         if(ctgMenu != NULL){
                 unpost_menu(ctgMenu);
                 free_menu(ctgMenu);

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -17,7 +17,7 @@ class CursesProvider{
                 CursesProvider(bool verbose, bool change);
                 void init();
                 void control();
-                void cleanup();
+                ~CursesProvider();
         private:
                 FeedlyProvider feedly;
                 WINDOW *ctgWin, *postsWin, *viewWin;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,6 @@
 namespace fs = std::filesystem;
 
 #define HOME_PATH getenv("HOME")
-CursesProvider *curses;
 std::string TMPDIR;
 
 void atExitFunction(){
@@ -33,8 +32,6 @@ void atExitFunction(){
                         fs::remove_all(path, errorCode);
                 }
         }
-
-        curses->cleanup();
 }
 
 void sighandler(int signum){
@@ -93,17 +90,11 @@ int main(int argc, char **argv){
                                 }
                         }
                 }
-                curses = new CursesProvider(verboseEnabled, changeTokens);
-        }
-        else{
-                curses = new CursesProvider(false, false);
         }
 
-
-        curses->init();
-        curses->control();
-
-        delete curses;
+        auto curses = CursesProvider(verboseEnabled, changeTokens);
+        curses.init();
+        curses.control();
         return 0;
 }
 


### PR DESCRIPTION
Feednix causes a segmentation fault when it's started with "-h" command line option because its cleanup logic tries to access a non-initialized pointer of `CursesProvider`.

This pull request moves the cleanup logic of `CursesProvider` to its destructor and initializes the pointer in a RAII (Resource Acquisition Is Initialization) approach.

I confirmed that `./feednix -h` with this change terminated successfully