### PR TITLE
Replace C arrays with std::vector

### DIFF
--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -22,7 +22,8 @@ class CursesProvider{
                 FeedlyProvider feedly;
                 WINDOW *ctgWin, *postsWin, *viewWin;
                 PANEL  *panels[3], *top;
-                ITEM **ctgItems, **postsItems;
+                std::vector<ITEM*> ctgItems{};
+                std::vector<ITEM*> postsItems{};
                 MENU *ctgMenu, *postsMenu;
                 std::string lastEntryRead, statusLine[3];
                 std::chrono::time_point<std::chrono::steady_clock> lastPostSelectionTime{std::chrono::time_point<std::chrono::steady_clock>::max()};
@@ -31,6 +32,8 @@ class CursesProvider{
                 int totalPosts = 0, numRead = 0, numUnread = 0;
                 int viewWinHeightPer = VIEW_WIN_HEIGHT_PER, viewWinHeight = 0, ctgWinWidth = CTG_WIN_WIDTH;
                 bool currentCategoryRead;
+                void clearCategoryItems();
+                void clearPostItems();
                 void createCategoriesMenu();
                 void createPostsMenu();
                 void changeSelectedItem(MENU* curMenu, int req);


### PR DESCRIPTION
Building Feednix with g++ 9.3.0 on Ubuntu 20.04.1 shows warnings on `ARRAY_SIZE`.  The calculation is wrong or at least difficult to understand.

```
CursesProvider.cpp:21:34: warning: division ‘sizeof (ITEM** {aka tagITEM**}) / sizeof (ITEM* {aka tagITEM*})’ does not compute the number of array elements [-Wsizeof-pointer-div]
   21 | #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
      |                        ~~~~~~~~~~^~~~~~~~~~~~~~
```

This pull request replaces C++ arrays with `std::vector`.  It also fixes a leak of `postsItems` when post items are refreshed by choosing another category.

I confirmed warnings were gone and Feednix worked without any noticeable problem on starting, terminating, marking articles as read, or navigating across categories.