### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = latin1
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+[*.{cpp,h}]
+indent_style = space
+indent_size = 8


### PR DESCRIPTION
This pull request adds an [EditorConfig](https://editorconfig.org) file to make it easy to follow the existing coding style.

I confirmed that Vim with [editorconfig-vim](https://github.com/editorconfig/editorconfig-vim) applied specified rules.