### PR TITLE
Mark unused variables

### DIFF
--- a/src/CursesProvider.cpp
+++ b/src/CursesProvider.cpp
@@ -467,7 +467,8 @@ void CursesProvider::createPostsMenu(){
 void CursesProvider::ctgMenuCallback(char* label){
         markItemReadAutomatically(current_item(postsMenu));
 
-        int startx, starty, height, width;
+        int startx, height, width;
+        [[maybe_unused]] int starty;
 
         getmaxyx(postsWin, height, width);
         getbegyx(postsWin, starty, startx);
@@ -651,7 +652,8 @@ void CursesProvider::markItemReadAutomatically(ITEM* item){
         lastPostSelectionTime = now;
 }
 void CursesProvider::win_show(WINDOW *win, char *label, int label_color, bool highlight){
-        int startx, starty, height, width;
+        int startx, width;
+        [[maybe_unused]] int starty, height;
 
         getbegyx(win, starty, startx);
         getmaxyx(win, height, width);


### PR DESCRIPTION
Building Feednix with g++ 9.3.0 on Ubuntu 20.04.1 LTS shows warnings on unused variables.

```
CursesProvider.cpp: In member function ‘void CursesProvider::ctgMenuCallback(char*)’:
CursesProvider.cpp:470:21: warning: variable ‘starty’ set but not used [-Wunused-but-set-variable]
  470 |         int startx, starty, height, width;
      |                     ^~~~~~
CursesProvider.cpp: In member function ‘void CursesProvider::win_show(WINDOW*, char*, int, bool)’:
CursesProvider.cpp:654:21: warning: variable ‘starty’ set but not used [-Wunused-but-set-variable]
  654 |         int startx, starty, height, width;
      |                     ^~~~~~
CursesProvider.cpp:654:29: warning: variable ‘height’ set but not used [-Wunused-but-set-variable]
  654 |         int startx, starty, height, width;
      |                             ^~~~~~
```

This pull request marks those unused variables with `[[maybe_unused]]`.

I confirmed that building Feednix with this change didn't show warnings above.