### PR TITLE
Fix menu initialization

### DIFF
--- a/src/CursesProvider.cpp
+++ b/src/CursesProvider.cpp
@@ -397,7 +397,7 @@ void CursesProvider::createCategoriesMenu(){
         win_show(ctgWin, strdup("Categories"),  2, false);
 
         menu_opts_off(ctgMenu, O_SHOWDESC);
-        menu_opts_on(postsMenu, O_NONCYCLIC);
+        menu_opts_on(ctgMenu, O_NONCYCLIC);
 
         post_menu(ctgMenu);
 }


### PR DESCRIPTION
During a feature development, I found a segmentation fault on creating the category menu.  `CursesProvider::createCategoriesMenu()` tries to set a menu option for the uninitialized post menu.

This pull request changes the method to set a menu option for the category menu instead.

I confirmed that Feednix with this change was able to launch, view articles, and mark articles as read without any issue.