### PR TITLE
Fix a bug where Feednix writes error logs to a random file

### DIFF
--- a/src/FeedlyProvider.cpp
+++ b/src/FeedlyProvider.cpp
@@ -13,9 +13,9 @@
 
 #include "FeedlyProvider.h"
 
-#define HOME_PATH getenv("HOME")
 extern std::string TMPDIR;
 
+namespace fs = std::filesystem;
 using namespace std::literals::string_literals;
 
 FeedlyProvider::FeedlyProvider(){
@@ -23,11 +23,14 @@ FeedlyProvider::FeedlyProvider(){
         verboseFlag = false;
 
         TEMP_PATH = TMPDIR + "/temp.txt";
+        const auto configRoot = fs::path{getenv("HOME")} / ".config" / "feednix";
+        configPath = configRoot / "config.json";
+        logPath = configRoot / "log.txt";
 
         Json::Value root;
         Json::Reader reader;
 
-        std::ifstream tokenFile(std::string(std::string(HOME_PATH) + "/.config/feednix/config.json").c_str(), std::ifstream::binary);
+        std::ifstream tokenFile(configPath.c_str(), std::ifstream::binary);
         if(reader.parse(tokenFile, root)){
                 rtrv_count = root["posts_retrive_count"].asString();
         }
@@ -36,8 +39,6 @@ FeedlyProvider::FeedlyProvider(){
 void FeedlyProvider::authenticateUser(){
         Json::Value root;
         Json::Reader reader;
-
-        std::string configPath = std::string(std::string(HOME_PATH) + "/.config/feednix/config.json");
 
         std::ifstream initialConfig(configPath.c_str(), std::ifstream::binary);
         bool parsingSuccesful = reader.parse(initialConfig, root);
@@ -382,8 +383,7 @@ Json::Value FeedlyProvider::curl_retrieve(const std::string& uri, const Json::Va
 }
 void FeedlyProvider::openLogStream(){
         if(!log_stream.is_open()){
-                const char* log_path = std::string(std::string(HOME_PATH) + "/.config/feednix/log.txt").c_str();
-                log_stream.open(log_path, std::ofstream::out | std::ofstream::app);
+                log_stream.open(logPath, std::ofstream::out | std::ofstream::app);
 
                 time_t current = time(NULL);
                 char* dt = ctime(&current);

--- a/src/FeedlyProvider.cpp
+++ b/src/FeedlyProvider.cpp
@@ -44,11 +44,12 @@ void FeedlyProvider::authenticateUser(){
         bool parsingSuccesful = reader.parse(initialConfig, root);
 
         if(!parsingSuccesful){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "ERROR: Log In Failed - Unable to read from config file" << std::endl;
                 log_stream << reader.getFormattedErrorMessages() << std::endl;
                 exit(EXIT_FAILURE);
         }
+
         if(root["developer_token"] == Json::nullValue || changeTokens){
                 std::cout << "You will now be redirected to Feedly's Developer Log In page..." << std::endl;
                 std::cout << "Please sign in, copy your user id and retrive the token from your email and copy it onto here." << std::endl;
@@ -94,7 +95,7 @@ void FeedlyProvider::authenticateUser(){
         initialConfig.close();
 
         user_data.authToken = (root["developer_token"]).asString();
-        user_data.id = (root["userID"]).asString(); 
+        user_data.id = (root["userID"]).asString();
 }
 const std::map<std::string, std::string>* FeedlyProvider::getLabels(){
         user_data.categories.clear();
@@ -109,7 +110,7 @@ const std::map<std::string, std::string>* FeedlyProvider::getLabels(){
                 }
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not get labels" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -136,7 +137,7 @@ const std::vector<PostData>* FeedlyProvider::giveStreamPosts(const std::string& 
                         root = curl_retrieve("streams/" + std::string(curl_easy_escape(curl, user_data.categories[category].c_str(), 0)) + "/contents?unreadOnly=true&ranked=newest&count=" + rtrv_count);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not get posts" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -181,7 +182,7 @@ void FeedlyProvider::markPostsRead(const std::vector<std::string>* ids){
                 curl_retrieve("markers", jsonCont);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not mark post(s) as read" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -203,7 +204,7 @@ void FeedlyProvider::markPostsUnread(const std::vector<std::string>* ids){
                 curl_retrieve("markers", jsonCont);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not mark post(s) as unread" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -225,7 +226,7 @@ void FeedlyProvider::markPostsSaved(const std::vector<std::string>* ids){
                 curl_retrieve("markers", jsonCont);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not mark post(s) as saved" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -247,7 +248,7 @@ void FeedlyProvider::markPostsUnsaved(const std::vector<std::string>* ids){
                 curl_retrieve("markers", jsonCont);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not mark post(s) as unsaved" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -269,7 +270,7 @@ void FeedlyProvider::markCategoriesRead(const std::string& id, const std::string
                 curl_retrieve("markers", jsonCont);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not mark category(ies) as read" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -299,7 +300,7 @@ void FeedlyProvider::addSubscription(bool newCategory, const std::string& feed, 
                 curl_retrieve("subscriptions", jsonCont);
         }
         catch(const std::exception& e){
-                if(!isLogStreamOpen) openLogStream();
+                openLogStream();
                 log_stream << "Could not add subscription" << std::endl;
                 log_stream << e.what() << std::endl;
                 throw;
@@ -389,8 +390,6 @@ void FeedlyProvider::openLogStream(){
                 char* dt = ctime(&current);
 
                 log_stream << "======== " << std::string(dt) << "\n";
-
-                isLogStreamOpen = true;
         }
 }
 void FeedlyProvider::echo(bool on = true){
@@ -403,6 +402,4 @@ void FeedlyProvider::echo(bool on = true){
 }
 void FeedlyProvider::curl_cleanup(){
         curl_global_cleanup();
-        if(log_stream.is_open())
-                log_stream.close();
 }

--- a/src/FeedlyProvider.h
+++ b/src/FeedlyProvider.h
@@ -1,5 +1,6 @@
 #include <curl/curl.h>
 #include <json/json.h>
+#include <filesystem>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -53,6 +54,8 @@ class FeedlyProvider{
                 std::string feedly_url;
                 std::string userAuthCode;
                 std::string TOKEN_PATH, TEMP_PATH, COOKIE_PATH, rtrv_count;
+                std::filesystem::path logPath;
+                std::filesystem::path configPath;
                 UserData user_data;
                 bool verboseFlag, changeTokens, isLogStreamOpen=false;
                 std::vector<PostData> feeds;

--- a/src/FeedlyProvider.h
+++ b/src/FeedlyProvider.h
@@ -57,7 +57,7 @@ class FeedlyProvider{
                 std::filesystem::path logPath;
                 std::filesystem::path configPath;
                 UserData user_data;
-                bool verboseFlag, changeTokens, isLogStreamOpen=false;
+                bool verboseFlag{}, changeTokens{};
                 std::vector<PostData> feeds;
                 void getCookies();
                 void enableVerbose();


### PR DESCRIPTION
Feednix generates a log file under the current directory with a random name when it hits a fatal error.  It's presumably because of a wrong use of `std::string(...).c_str()` which may free the buffer just after the call.

This pull request changes to keep the log file path as `FeedlyProvider::logPath` so that the path character buffer is always valid during the Feedly provider lifetime.

I confirmed that Feednix with this change appended error logs to `~\.config\feednix\log.txt` when `~\.config\feednix\config.json` was illformed.