### PR TITLE
Call curl_free for every curl_easy_escape string

### DIFF
--- a/src/FeedlyProvider.h
+++ b/src/FeedlyProvider.h
@@ -13,6 +13,8 @@
 #ifndef _PROVIDER_H_
 #define _PROVIDER_H_
 
+using CurlString = std::unique_ptr<char, decltype(&curl_free)>;
+
 struct UserData{
         std::map<std::string, std::string> categories;
         std::string id;
@@ -65,6 +67,7 @@ class FeedlyProvider{
                 void extract_galx_value();
                 void echo(bool on);
                 void openLogStream();
+                CurlString escapeCurlString(const std::string& s);
 };
 
 #endif


### PR DESCRIPTION
According to `man curl_easy_escape`, we must call `curl_free` for every string returned from `curl_easy_escape`.  However, currently Feednix doesn't do that.

This pull request adds a type named `CurlString` based on `std::unique_ptr` to ensure calling `curl_free` when a string returned from `curl_easy_escape` becomes unnecessary.

I confirmed that Feednix with this change was still able to show articles in "All" category without any issue.