### PR TITLE
Add text_browser option

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-        "colors" : { 
+        "colors" : {
 
                 /* ====== Color Definitions =======
                  *  BLACK   0
@@ -28,11 +28,12 @@
         // Count of posts to be retrived per request. Maximum is 10000
         "posts_retrive_count" : "500",
         //Feedly API Allows for two sort types:
-                // Newest(default) false 
-                // Oldest true 
+                // Newest(default) false
+                // Oldest true
         "rank" : false,
         // Mark an article as read if it has been shown for more than the specified seconds.
         // A negative value indicates that the article won't be marked as read
         // unless you open it with the browser or mark it as read explicitly.
-        "seconds_to_mark_as_read": 0
+        "seconds_to_mark_as_read": 0,
+        "text_browser": "w3m"
 }

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -28,6 +28,7 @@ class CursesProvider{
                 std::string lastEntryRead, statusLine[3];
                 std::chrono::time_point<std::chrono::steady_clock> lastPostSelectionTime{std::chrono::time_point<std::chrono::steady_clock>::max()};
                 std::chrono::seconds secondsToMarkAsRead;
+                std::string textBrowser;
                 bool currentRank = 0;
                 int totalPosts = 0, numRead = 0, numUnread = 0;
                 int viewWinHeightPer = VIEW_WIN_HEIGHT_PER, viewWinHeight = 0, ctgWinWidth = CTG_WIN_WIDTH;


### PR DESCRIPTION
Feednix uses w3m for opening a post in the console.  I personally prefer another text browser such as [rdrview](https://github.com/eafer/rdrview) to read the content in a clean view.

To support the scenario, this pull request adds a new option named `text_browser` to specify the default text browser to open a post in the console.  It also supports `BROWSER` environment variable to override the default text browser.  The priority order is as follows.

1. Use `BROWSER` environment variable if it's set.
2. Use `text_browser` option if it's set.
3. Use `w3m`.

This pull request also introduces a consolidated logic for previewing and opening a post with some error handling.

I confirmed that:

- Feednix opens a post with a text browser specified by `BROWSER` environment variable and ignores `text_browser` option when `BROWSER` environment variable is specified.
- Feednix opens a post with a text browser (rdrview) specified by `text_browser` option.
- Feednix opens a post with w3m when no text browser is specified by `BROWSER` environment variable and `text_browser` option.