### PR TITLE
Ignore unsupported key bindings

### DIFF
--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -38,7 +38,7 @@ class CursesProvider{
                 void createCategoriesMenu();
                 void createPostsMenu();
                 void changeSelectedItem(MENU* curMenu, int req);
-                void ctgMenuCallback(char* label);
+                void ctgMenuCallback(const char* label);
                 void postsMenuCallback(ITEM* item, bool preview);
                 void markItemRead(ITEM* item);
                 void markItemReadAutomatically(ITEM* item);


### PR DESCRIPTION
Pressing 'r' when the category menu is selected in Feednix shows the current category as read (i.e. render it in dark yellow) but it actually does nothing.  In addition, Feednix crashes due to a segmentation fault on pressing some keys when there is no post in the current category.

This pull request ignores some key bindings supported only in a specific menu of Feednix when the correct menu is not selected.  It also adds check the existence of the current item to avoid segmentation faults.  Lastly, it eliminates unnecessary string duplications that never get freed.

I confirmed that:
- Pressing 'o', 'O', 'r', 'u', 's', and 'S' did nothing when the category menu is selected.
- Pressing 'o', 'O', 'r', 'u', 's', and 'S' keeps the current behavior when the post menu is selected.
- Pressing Enter key keeps the current behavior in both the category menu and the post menu.