### PR TITLE
Replace rm and TMPDIR using std::filesystem

### DIFF
--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -14,7 +14,7 @@
 
 class CursesProvider{
         public:
-                CursesProvider(bool verbose, bool change);
+                CursesProvider(const std::filesystem::path& tmpPath, bool verbose, bool change);
                 void init();
                 void control();
                 ~CursesProvider();
@@ -29,10 +29,11 @@ class CursesProvider{
                 std::chrono::time_point<std::chrono::steady_clock> lastPostSelectionTime{std::chrono::time_point<std::chrono::steady_clock>::max()};
                 std::chrono::seconds secondsToMarkAsRead;
                 std::string textBrowser;
+                const std::filesystem::path previewPath;
                 bool currentRank = 0;
                 int totalPosts = 0, numRead = 0, numUnread = 0;
                 int viewWinHeightPer = VIEW_WIN_HEIGHT_PER, viewWinHeight = 0, ctgWinWidth = CTG_WIN_WIDTH;
-                bool currentCategoryRead;
+                bool currentCategoryRead{};
                 void clearCategoryItems();
                 void clearPostItems();
                 void createCategoriesMenu();

--- a/src/FeedlyProvider.h
+++ b/src/FeedlyProvider.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <string>
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <vector>
@@ -34,7 +35,7 @@ struct PostData{
 
 class FeedlyProvider{
         public:
-                FeedlyProvider();
+                FeedlyProvider(const std::filesystem::path& tmpDir);
                 void authenticateUser();
                 void markPostsRead(const std::vector<std::string>* ids);
                 void markPostsSaved(const std::vector<std::string>* ids);
@@ -55,7 +56,8 @@ class FeedlyProvider{
                 std::ofstream log_stream;
                 std::string feedly_url;
                 std::string userAuthCode;
-                std::string TOKEN_PATH, TEMP_PATH, COOKIE_PATH, rtrv_count;
+                std::string TOKEN_PATH, COOKIE_PATH, rtrv_count;
+                const std::filesystem::path tempPath;
                 std::filesystem::path logPath;
                 std::filesystem::path configPath;
                 UserData user_data;


### PR DESCRIPTION
Building Feednix with g++ 9.3.0 on Ubuntu 20.04.1 LTS shows the following error.

```
CursesProvider.cpp: In member function ‘void CursesProvider::postsMenuCallback(ITEM*, bool)’:
CursesProvider.cpp:639:15: warning: ignoring return value of ‘int system(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
  639 |         system(std::string("rm " + TMPDIR + "/preview.html 2> /dev/null").c_str());
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This pull request makes following changes.

- Replace `system("rm ...")` with `std::filesystem::remove` to remove a temporary file in a more portable way.
- Replace `TMPDIR` global string with `TMPDIR` static path to be passed to `CursesProvider` and `FeedlyProvider` as their constructor argument to reduce the complexity around handling a global variable.
- Introduce `PipeStream` and `FileStream` based on `std::unique_ptr` to handle streams in a RAII (Resource Acquisition Is Initialization) way.

I confirmed that Feednix with this change created and deleted a temporary directory and file on launching and terminating.