### PR TITLE
Add GitHub Action for the continuous integration build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,27 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: apt-get install
+      run: sudo apt-get --yes install dh-autoreconf libjsoncpp-dev libcurl4-gnutls-dev libncurses5-dev
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/README.md
+++ b/README.md
@@ -21,20 +21,6 @@ Thank you @chrisjohnston for mentioning the following dependencies for Ubuntu:
 sudo apt-get install dh-autoreconf libjsoncpp-dev libcurl4-gnutls-dev libncurses5-dev
 ```
 
-`make` may give you the following error.
-
-```
-CursesProvider.cpp:18:10: fatal error: json/json.h: No such file or directory
-18 | #include <json/json.h>
-   |          ^~~~~~~~~~~~~
-```
-
-Give the following `CPPFLAGS` value when you `configure` to work around it.
-
-```sh
-./configure CPPFLAGS='-I/usr/include/jsoncpp'
-```
-
 ### macOS
 
 For macOS with [Homebrew](https://brew.sh), install the prerequisites with:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,6 +7,12 @@ feednix_SOURCES = \
 	FeedlyProvider.h \
 	main.cpp
 
-feednix_CPPFLAGS = -DDEBUG -std=c++17 -Wall
+feednix_CPPFLAGS = \
+	-std=c++17 \
+	-Wall \
+	-I/usr/include/jsoncpp \
+	-DDEBUG \
+	$(AM_CFLAGS)
+
 AM_CFLAGS = -lcurl -ljsoncpp -lmenuw -lpanelw -lncursesw
 AM_LIBS = curl jsoncpp menuw panelw ncursesw


### PR DESCRIPTION
This pull request adds a GitHub Action to re-enable the continuous integration build for master branch. It also adds  `-I/usr/include/jsoncpp` to `feednix_CPPFLAGS` for making a build on Ubuntu succeed by default.

Since Travis CI stopped working, Feednix has no continuous integration build. Re-enabling it using GitHub Action will help developers avoid breaking the build and installation.

I confirmed that [the same GitHub Action succeeded on my fork](https://github.com/masaru-iritani/Feednix/pull/3/checks?check_run_id=1961040390). I also confirmed that `./autogen.sh && ./configure && make && make distcheck && sudo make install` succeeded on Ubuntu 20.04.1 LTS.