### PR TITLE
Replace ctime with thread-safe functions

### DIFF
--- a/src/FeedlyProvider.cpp
+++ b/src/FeedlyProvider.cpp
@@ -402,9 +402,14 @@ void FeedlyProvider::openLogStream(){
                 log_stream.open(logPath, std::ofstream::out | std::ofstream::app);
 
                 time_t current = time(NULL);
-                char* dt = ctime(&current);
+                struct tm localTime{};
+                localtime_r(&current, &localTime);
 
-                log_stream << "======== " << std::string(dt) << "\n";
+                auto buffer = std::array<char, 64>{};
+                if(const auto result = strftime(buffer.data(), buffer.size(), "%a, %d %b %Y %T %z", &localTime); result > 0)
+                {
+                        log_stream << "======== " << buffer.data() << std::endl;
+                }
         }
 }
 void FeedlyProvider::echo(bool on = true){


### PR DESCRIPTION
Feednix uses `ctime` for outputting the current time to a log file when an error happened. However, [the CodeQL analysis](https://codeql.github.com/codeql-query-help/cpp/cpp-potentially-dangerous-function/) warns its use because it's not thread-safe. In addition, `ctime` is marked as obsolete according to [`man 3 ctime_r`](https://man.archlinux.org/man/core/man-pages/ctime_r.3.en).

This pull request replaces `ctime` with `localtime_r` and `strftime`. We will be able to enable the CodeQL analysis without any warning after the change. `ctime_r` is not used because it's marked as obsolete, too.