### PR TITLE
Remove unnecessary strdup

### DIFF
--- a/src/CursesProvider.cpp
+++ b/src/CursesProvider.cpp
@@ -159,16 +159,16 @@ void CursesProvider::control(){
                                 if(curMenu == ctgMenu){
                                         curMenu = postsMenu;
 
-                                        win_show(postsWin, "Posts", 1, true);
-                                        win_show(ctgWin, "Categories", 2, false);
+                                        renderWindow(postsWin, "Posts", 1, true);
+                                        renderWindow(ctgWin, "Categories", 2, false);
 
                                         update_infoline(POSTS_STATUSLINE);
                                         refresh();
                                 }
                                 else{
                                         curMenu = ctgMenu;
-                                        win_show(ctgWin, "Categories", 1, true);
-                                        win_show(postsWin, "Posts", 2, false);
+                                        renderWindow(ctgWin, "Categories", 1, true);
+                                        renderWindow(postsWin, "Posts", 2, false);
 
                                         update_infoline(CTG_STATUSLINE);
 
@@ -417,7 +417,7 @@ void CursesProvider::createCategoriesMenu(){
 
         set_menu_mark(ctgMenu, "  ");
 
-        win_show(ctgWin, "Categories", 2, false);
+        renderWindow(ctgWin, "Categories", 2, false);
 
         menu_opts_off(ctgMenu, O_SHOWDESC);
         menu_opts_on(ctgMenu, O_NONCYCLIC);
@@ -468,14 +468,14 @@ void CursesProvider::createPostsMenu(){
 
         set_menu_mark(postsMenu, "*");
 
-        win_show(postsWin, "Posts", 1, true);
+        renderWindow(postsWin, "Posts", 1, true);
 
         menu_opts_off(postsMenu, O_SHOWDESC);
 
         post_menu(postsMenu);
 
         if(numUnread == 0){
-                print_in_center(postsWin, 3, 1, height, width - 4, "All Posts Read", 1);
+                printInCenter(postsWin, 3, 1, height, width - 4, "All Posts Read", 1);
         }
 }
 void CursesProvider::ctgMenuCallback(const char* label){
@@ -509,9 +509,9 @@ void CursesProvider::ctgMenuCallback(const char* label){
                 set_menu_items(postsMenu, NULL);
                 post_menu(postsMenu);
 
-                print_in_center(postsWin, 3, 1, height, width - 4, "All Posts Read", 1);
-                win_show(postsWin, "Posts", 2, false);
-                win_show(ctgWin, "Categories", 1, true);
+                printInCenter(postsWin, 3, 1, height, width - 4, "All Posts Read", 1);
+                renderWindow(postsWin, "Posts", 2, false);
+                renderWindow(ctgWin, "Categories", 1, true);
 
                 currentCategoryRead = true;
                 update_statusline(errorMessage.c_str(), NULL, errorMessage.empty());
@@ -533,8 +533,8 @@ void CursesProvider::ctgMenuCallback(const char* label){
         currentCategoryRead = false;
 
         update_statusline("", NULL, true);
-        win_show(postsWin, "Posts", 1, true);
-        win_show(ctgWin, "Categories", 2, false);
+        renderWindow(postsWin, "Posts", 1, true);
+        renderWindow(ctgWin, "Categories", 2, false);
 
         changeSelectedItem(postsMenu, REQ_FIRST_ITEM);
 }
@@ -652,7 +652,7 @@ void CursesProvider::markItemReadAutomatically(ITEM* item){
 
         lastPostSelectionTime = now;
 }
-void CursesProvider::win_show(WINDOW *win, const char *label, int label_color, bool highlight){
+void CursesProvider::renderWindow(WINDOW *win, const char *label, int label_color, bool highlight){
         int startx, width;
         [[maybe_unused]] int starty, height;
 
@@ -669,7 +669,7 @@ void CursesProvider::win_show(WINDOW *win, const char *label, int label_color, b
                 mvwaddch(win, 2, 0, ACS_LTEE);
                 mvwhline(win, 2, 1, ACS_HLINE, width - 2);
                 mvwaddch(win, 2, width - 1, ACS_RTEE);
-                print_in_middle(win, 1, 0, width, label, COLOR_PAIR(label_color));
+                printInMiddle(win, 1, 0, width, label, COLOR_PAIR(label_color));
                 wattroff(win, COLOR_PAIR(label_color));
         }
         else{
@@ -678,12 +678,12 @@ void CursesProvider::win_show(WINDOW *win, const char *label, int label_color, b
                 mvwaddch(win, 2, 0, ACS_LTEE);
                 mvwhline(win, 2, 1, ACS_HLINE, width - 2);
                 mvwaddch(win, 2, width - 1, ACS_RTEE);
-                print_in_middle(win, 1, 0, width, label, COLOR_PAIR(5));
+                printInMiddle(win, 1, 0, width, label, COLOR_PAIR(5));
                 wattroff(win, COLOR_PAIR(2));
         }
 
 }
-void CursesProvider::print_in_middle(WINDOW *win, int starty, int startx, int width, const char *str, chtype color){
+void CursesProvider::printInMiddle(WINDOW *win, int starty, int startx, int width, const char *str, chtype color){
         int length, x, y;
         float temp;
 
@@ -702,7 +702,7 @@ void CursesProvider::print_in_middle(WINDOW *win, int starty, int startx, int wi
         x = startx + (int)temp;
         mvwprintw(win, y, x, "%s", str);
 }
-void CursesProvider::print_in_center(WINDOW *win, int starty, int startx, int height, int width, const char *str, chtype color){
+void CursesProvider::printInCenter(WINDOW *win, int starty, int startx, int height, int width, const char *str, chtype color){
         int length, x, y;
         float tempX, tempY;
 

--- a/src/CursesProvider.cpp
+++ b/src/CursesProvider.cpp
@@ -159,16 +159,16 @@ void CursesProvider::control(){
                                 if(curMenu == ctgMenu){
                                         curMenu = postsMenu;
 
-                                        win_show(postsWin, strdup("Posts"), 1, true);
-                                        win_show(ctgWin, strdup("Categories"), 2, false);
+                                        win_show(postsWin, "Posts", 1, true);
+                                        win_show(ctgWin, "Categories", 2, false);
 
                                         update_infoline(POSTS_STATUSLINE);
                                         refresh();
                                 }
                                 else{
                                         curMenu = ctgMenu;
-                                        win_show(ctgWin, strdup("Categories"), 1, true);
-                                        win_show(postsWin, strdup("Posts"), 2, false);
+                                        win_show(ctgWin, "Categories", 1, true);
+                                        win_show(postsWin, "Posts", 2, false);
 
                                         update_infoline(CTG_STATUSLINE);
 
@@ -417,7 +417,7 @@ void CursesProvider::createCategoriesMenu(){
 
         set_menu_mark(ctgMenu, "  ");
 
-        win_show(ctgWin, strdup("Categories"),  2, false);
+        win_show(ctgWin, "Categories", 2, false);
 
         menu_opts_off(ctgMenu, O_SHOWDESC);
         menu_opts_on(ctgMenu, O_NONCYCLIC);
@@ -468,14 +468,14 @@ void CursesProvider::createPostsMenu(){
 
         set_menu_mark(postsMenu, "*");
 
-        win_show(postsWin, strdup("Posts"), 1, true);
+        win_show(postsWin, "Posts", 1, true);
 
         menu_opts_off(postsMenu, O_SHOWDESC);
 
         post_menu(postsMenu);
 
         if(numUnread == 0){
-                print_in_center(postsWin, 3, 1, height, width-4, strdup("All Posts Read"), 1);
+                print_in_center(postsWin, 3, 1, height, width - 4, "All Posts Read", 1);
         }
 }
 void CursesProvider::ctgMenuCallback(const char* label){
@@ -509,9 +509,9 @@ void CursesProvider::ctgMenuCallback(const char* label){
                 set_menu_items(postsMenu, NULL);
                 post_menu(postsMenu);
 
-                print_in_center(postsWin, 3, 1, height, width-4, strdup("All Posts Read"), 1);
-                win_show(postsWin, strdup("Posts"), 2, false);
-                win_show(ctgWin, strdup("Categories"), 1, true);
+                print_in_center(postsWin, 3, 1, height, width - 4, "All Posts Read", 1);
+                win_show(postsWin, "Posts", 2, false);
+                win_show(ctgWin, "Categories", 1, true);
 
                 currentCategoryRead = true;
                 update_statusline(errorMessage.c_str(), NULL, errorMessage.empty());
@@ -533,8 +533,8 @@ void CursesProvider::ctgMenuCallback(const char* label){
         currentCategoryRead = false;
 
         update_statusline("", NULL, true);
-        win_show(postsWin, strdup("Posts"), 1, true);
-        win_show(ctgWin, strdup("Categories"), 2, false);
+        win_show(postsWin, "Posts", 1, true);
+        win_show(ctgWin, "Categories", 2, false);
 
         changeSelectedItem(postsMenu, REQ_FIRST_ITEM);
 }
@@ -652,7 +652,7 @@ void CursesProvider::markItemReadAutomatically(ITEM* item){
 
         lastPostSelectionTime = now;
 }
-void CursesProvider::win_show(WINDOW *win, char *label, int label_color, bool highlight){
+void CursesProvider::win_show(WINDOW *win, const char *label, int label_color, bool highlight){
         int startx, width;
         [[maybe_unused]] int starty, height;
 
@@ -683,7 +683,7 @@ void CursesProvider::win_show(WINDOW *win, char *label, int label_color, bool hi
         }
 
 }
-void CursesProvider::print_in_middle(WINDOW *win, int starty, int startx, int width, char *str, chtype color){
+void CursesProvider::print_in_middle(WINDOW *win, int starty, int startx, int width, const char *str, chtype color){
         int length, x, y;
         float temp;
 
@@ -702,7 +702,7 @@ void CursesProvider::print_in_middle(WINDOW *win, int starty, int startx, int wi
         x = startx + (int)temp;
         mvwprintw(win, y, x, "%s", str);
 }
-void CursesProvider::print_in_center(WINDOW *win, int starty, int startx, int height, int width, char *str, chtype color){
+void CursesProvider::print_in_center(WINDOW *win, int starty, int startx, int height, int width, const char *str, chtype color){
         int length, x, y;
         float tempX, tempY;
 

--- a/src/CursesProvider.cpp
+++ b/src/CursesProvider.cpp
@@ -652,7 +652,7 @@ void CursesProvider::markItemReadAutomatically(ITEM* item){
 
         lastPostSelectionTime = now;
 }
-void CursesProvider::renderWindow(WINDOW *win, const char *label, int label_color, bool highlight){
+void CursesProvider::renderWindow(WINDOW *win, const char *label, int labelColor, bool highlight){
         int startx, width;
         [[maybe_unused]] int starty, height;
 
@@ -664,13 +664,13 @@ void CursesProvider::renderWindow(WINDOW *win, const char *label, int label_colo
         mvwaddch(win, 2, width - 1, ACS_RTEE);
 
         if(highlight){
-                wattron(win, COLOR_PAIR(label_color));
+                wattron(win, COLOR_PAIR(labelColor));
                 box(win, 0, 0);
                 mvwaddch(win, 2, 0, ACS_LTEE);
                 mvwhline(win, 2, 1, ACS_HLINE, width - 2);
                 mvwaddch(win, 2, width - 1, ACS_RTEE);
-                printInMiddle(win, 1, 0, width, label, COLOR_PAIR(label_color));
-                wattroff(win, COLOR_PAIR(label_color));
+                printInMiddle(win, 1, 0, width, label, COLOR_PAIR(labelColor));
+                wattroff(win, COLOR_PAIR(labelColor));
         }
         else{
                 wattron(win, COLOR_PAIR(2));

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -43,9 +43,9 @@ class CursesProvider{
                 void postsMenuCallback(ITEM* item, bool preview);
                 void markItemRead(ITEM* item);
                 void markItemReadAutomatically(ITEM* item);
-                void win_show(WINDOW *win, const char *label, int label_color, bool highlight);
-                void print_in_middle(WINDOW *win, int starty, int startx, int width, const char *string, chtype color);
-                void print_in_center(WINDOW *win, int starty, int startx, int height, int width, const char *string, chtype color);
+                void renderWindow(WINDOW *win, const char *label, int label_color, bool highlight);
+                void printInMiddle(WINDOW *win, int starty, int startx, int width, const char *string, chtype color);
+                void printInCenter(WINDOW *win, int starty, int startx, int height, int width, const char *string, chtype color);
                 void clear_statusline();
                 void update_statusline(const char* update, const char* post, bool showCounter);
                 void update_infoline(const char* info);

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -43,7 +43,7 @@ class CursesProvider{
                 void postsMenuCallback(ITEM* item, bool preview);
                 void markItemRead(ITEM* item);
                 void markItemReadAutomatically(ITEM* item);
-                void renderWindow(WINDOW *win, const char *label, int label_color, bool highlight);
+                void renderWindow(WINDOW *win, const char *label, int labelColor, bool highlight);
                 void printInMiddle(WINDOW *win, int starty, int startx, int width, const char *string, chtype color);
                 void printInCenter(WINDOW *win, int starty, int startx, int height, int width, const char *string, chtype color);
                 void clear_statusline();

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -43,9 +43,9 @@ class CursesProvider{
                 void postsMenuCallback(ITEM* item, bool preview);
                 void markItemRead(ITEM* item);
                 void markItemReadAutomatically(ITEM* item);
-                void win_show(WINDOW *win, char *label, int label_color, bool highlight);
-                void print_in_middle(WINDOW *win, int starty, int startx, int width, char *string, chtype color);
-                void print_in_center(WINDOW *win, int starty, int startx, int height, int width, char *string, chtype color);
+                void win_show(WINDOW *win, const char *label, int label_color, bool highlight);
+                void print_in_middle(WINDOW *win, int starty, int startx, int width, const char *string, chtype color);
+                void print_in_center(WINDOW *win, int starty, int startx, int height, int width, const char *string, chtype color);
                 void clear_statusline();
                 void update_statusline(const char* update, const char* post, bool showCounter);
                 void update_infoline(const char* info);


### PR DESCRIPTION
Feednix uses `strdup` in several places. However, it's unnecessary because the final consumer of strings, `mvwprintw` doesn't require the buffer duplication. In addition, duplicated buffers are not freed, and causing memory leaks.

This pull request removes unnecessary `strdup` and updates methods to handle constant characters. It also includes method renames to follow a single naming convention (camelCase).

I confirmed that Feednix with this change can render panel labels correctly when it launched and came back from `w3m` previewing a post.