### PR TITLE
Erase post menu before printing message

### DIFF
--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <iostream>
+
 #include <curses.h>
 #include <menu.h>
 #include <panel.h>
@@ -20,7 +21,7 @@ class CursesProvider{
                 ~CursesProvider();
         private:
                 FeedlyProvider feedly;
-                WINDOW *ctgWin, *postsWin, *viewWin;
+                WINDOW *ctgWin, *postsWin, *viewWin, *ctgMenuWin, *postsMenuWin;
                 PANEL  *panels[3], *top;
                 std::vector<ITEM*> ctgItems{};
                 std::vector<ITEM*> postsItems{};
@@ -30,10 +31,10 @@ class CursesProvider{
                 std::chrono::seconds secondsToMarkAsRead;
                 std::string textBrowser;
                 const std::filesystem::path previewPath;
-                bool currentRank = 0;
-                int totalPosts = 0, numRead = 0, numUnread = 0;
+                bool currentRank{};
+                unsigned int totalPosts{};
+                unsigned int numUnread{};
                 int viewWinHeightPer = VIEW_WIN_HEIGHT_PER, viewWinHeight = 0, ctgWinWidth = CTG_WIN_WIDTH;
-                bool currentCategoryRead{};
                 void clearCategoryItems();
                 void clearPostItems();
                 void createCategoriesMenu();
@@ -45,7 +46,7 @@ class CursesProvider{
                 void markItemReadAutomatically(ITEM* item);
                 void renderWindow(WINDOW *win, const char *label, int labelColor, bool highlight);
                 void printInMiddle(WINDOW *win, int starty, int startx, int width, const char *string, chtype color);
-                void printInCenter(WINDOW *win, int starty, int startx, int height, int width, const char *string, chtype color);
+                void printPostMenuMessage(const std::string& message);
                 void clear_statusline();
                 void update_statusline(const char* update, const char* post, bool showCounter);
                 void update_infoline(const char* info);


### PR DESCRIPTION
Feednix shows "All Posts Read" message when there is no unread post in the current category. However, the message is not cleared on switching between categories. Therefore, when the new category has a few posts, the message keeps showing.

This pull request updates `CursesProvider` as follows.

* Erase the post menu message in `printPostMenuMessage` (renamed from `printInCenter`).
* Show "Loading..." message in the post menu window on launch.
* Stop fetching posts on creating the post menu and call `ctgMenuCallback("All")` instead to consolidate the post fetch logic.
* Consolidate `ctgMenuCallback` logic to handle categories with and without unread posts.
* Replace `currentCategoryRead` and `numRead` with calculations using other fields.

I confirmed following things on Feednix with this change.

* "Loading..." is shown in the middle center of the post menu on launch.
* "Loading..." is overwritten with the post menu after loading posts.
* "All Posts Read" is shown after marking all posts as read.
* "All Posts Read" is shown after switching to a category without unread posts.
* "All Posts Read" is erased after switching a category without unread posts to another category with 1 unread post.