### PR TITLE
Run apt-get update in GitHub workflows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: apt-get update
+      run: sudo apt-get update
     - name: apt-get install
       run: sudo apt-get --yes install dh-autoreconf libjsoncpp-dev libcurl4-gnutls-dev libncurses5-dev
     - name: autogen

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+    - name: apt-get update
+      run: sudo apt-get update
     - name: apt-get install
       run: sudo apt-get --yes install dh-autoreconf libjsoncpp-dev libcurl4-gnutls-dev libncurses5-dev
 


### PR DESCRIPTION
GitHub workflows for Feednix started to fail because of a failure in `apt-get install` due to a stale index file.

This pull request fixes the failure by running `apt-get update` beforehand. I confirmed GitHub workflows with this change succeeded for [pull request builds in my fork](https://github.com/masaru-iritani/Feednix/actions?query=branch:update_apt).