### PR TITLE
Fork instead of calling system

### DIFF
--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -50,7 +50,7 @@ class CursesProvider{
                 void clear_statusline();
                 void update_statusline(const char* update, const char* post, bool showCounter);
                 void update_infoline(const char* info);
-                int execute(const char* command, const char* arg);
+                int execute(const std::string& command, const std::string& arg);
 };
 
 #endif

--- a/src/CursesProvider.h
+++ b/src/CursesProvider.h
@@ -50,6 +50,7 @@ class CursesProvider{
                 void clear_statusline();
                 void update_statusline(const char* update, const char* post, bool showCounter);
                 void update_infoline(const char* info);
+                int execute(const char* command, const char* arg);
 };
 
 #endif


### PR DESCRIPTION
Feednix uses `system()` to launch a web browser. However, it has a security risk because a URL is passed to `system()` without any validation or sanitization. A website can make Feednix run any command via a malicious URL.

This change makes following changes.

- Replace `system()` using unreliable parameters with `fork()`.
- Skip suppressing the standard output in a console session to allow `O` key to launch a web browser in a console session.
- Replace "~" with `$HOME` because `fork` doesn't handle it.
- Remove an unused `CTRLD` variable.

I confirmed following things using Feednix with this change.

- Feednix can launch a web browser (Firefox) in a GUI session on `O` key without outputting any error message.
- Feednix can launch a web browser (w3m) in a console session on `O` key.
- Feednix can launch a text web browser when its path starts with "~/".